### PR TITLE
Fix type mismatch bug in disregard_self feature

### DIFF
--- a/groupme_push/client.py
+++ b/groupme_push/client.py
@@ -40,7 +40,7 @@ class PushClient:
                 timeout=5,
             )
             user = json.loads(resp.text)
-            self.user_id = user["response"]["user_id"]
+            self.user_id = int(user["response"]["user_id"])
 
             handshake = {
                 "channel": "/meta/handshake",


### PR DESCRIPTION
Converts self.user_id to integer when retrieved from API to ensure proper comparison with sender_id. This fixes the disregard_self feature which was failing due to comparing int to string.

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)