### PR TITLE
Add automatic reconnection support for websocket

### DIFF
--- a/groupme_push/client.py
+++ b/groupme_push/client.py
@@ -21,6 +21,7 @@ class PushClient:
         on_favorite=None,
         on_other=None,
         disregard_self=False,
+        reconnect=None,
     ):
         self.id = 1
         self.access_token = access_token
@@ -30,6 +31,7 @@ class PushClient:
         self.favorite_callback = on_favorite
         self.other_callback = on_other
         self.disregard_self = disregard_self
+        self.reconnect = reconnect
 
     def start(self):
         try:
@@ -76,7 +78,10 @@ class PushClient:
             on_open=self.on_open,
         )
 
-        self.ws.run_forever()
+        if self.reconnect is not None:
+            self.ws.run_forever(reconnect=self.reconnect)
+        else:
+            self.ws.run_forever()
 
     def bump_id(self):
         self.id += 1

--- a/readme.MD
+++ b/readme.MD
@@ -12,11 +12,12 @@ import `from  groupme_push.client  import  PushClient`
 PushClient has a couple of paramaters:
 - **access_token** - GroupMe access token for the user that you want to listen for
 - **on_message** -  a function to call whenver there is a new message in any group the user is in
-- **on_dm** - callback for DMs 
+- **on_dm** - callback for DMs
 - **on_like** - callback for when another user likes a message
 - **on_favorite** - callback for when your user likes a message
 - **on_other** - for any other type of message, such as poll results
 - **disregard_self** - if the listener should disregard messages originating from the user
+- **reconnect** - delay in seconds before reconnecting after connection loss (default: None, no reconnection)
 
 create a PushClient object with 
 `client = PushClient(access_token=groupme_access_token)`


### PR DESCRIPTION
Adds a 'reconnect' parameter to PushClient that allows automatic reconnection when the websocket connection is lost. This fixes the issue where connections would drop after ~24 hours (GroupMe's max connection lifetime) without any way to recover.

Usage:
  client = PushClient(access_token=token, reconnect=20)

The reconnect parameter specifies the delay in seconds before attempting to reconnect after a connection error.

Fixes #4